### PR TITLE
feat: migrate radian install to uv tool install

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -75,7 +75,7 @@ p6df::modules::R::langs() {
   # XXX: install packages - languageserver, linter, httpgd
 
   # cli tools
-  pip install radian
+  uv tool install radian
 
   p6_return_void
 }


### PR DESCRIPTION
## Summary
- Replaces `pip install radian` with `uv tool install radian` in `p6df::modules::R::langs()`
- Aligns radian installation with the project-wide uv toolchain standard

## Test plan
- [ ] Verify `uv tool install radian` succeeds in a clean R environment
- [ ] Confirm `radian` is available in PATH after install

🤖 Generated with [Claude Code](https://claude.com/claude-code)