### PR TITLE
fix(profile): correct env var reference in profile mod

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -144,5 +144,5 @@ p6df::modules::R::prompt::lang() {
 ######################################################################
 p6df::modules::R::prompt::env() {
 
-  p6_return_words 'R' "$"
+  p6_return_words 'R' '$RENV_ROOT'
 }


### PR DESCRIPTION
## What
Fix the `p6df::modules::R::prompt::env()` function to use `'$RENV_ROOT'` instead of a bare `"$"` as the env var argument to `p6_return_words`.

## Why
The previous value `"$"` was a broken/placeholder string that would not correctly reference the R environment root path variable. This fix ensures the profile mod returns the correct env var name.

## Test plan
- Verified diff looks correct
- Function now references `\$RENV_ROOT` as intended

## Dependencies
None