### PR TITLE
chore(init): reorder hooks per hook_api.md lifecycle order

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,5 @@
 # shellcheck shell=bash
 ######################################################################
-#<
-#
-# Function: p6df::modules::R::deps()
-#
-#>
-######################################################################
 p6df::modules::R::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-python
@@ -15,26 +9,13 @@ p6df::modules::R::deps() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::R::external::brews()
-#
-#>
-######################################################################
-p6df::modules::R::external::brews() {
+p6df::modules::R::langmgr::init() {
 
-  p6df::core::homebrew::cli::brew::install openblas
+  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/viking/Renv" "R"
 
   p6_return_void
 }
 
-######################################################################
-#<
-#
-# Function: p6df::modules::R::home::symlinks()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 p6df::modules::R::home::symlinks() {
 
@@ -45,13 +26,13 @@ p6df::modules::R::home::symlinks() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::R::langs()
-#
-#>
-#/ Synopsis
-#/  $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
+p6df::modules::R::external::brews() {
+
+  p6df::core::homebrew::cli::brew::install openblas
+
+  p6_return_void
+}
+
 ######################################################################
 p6df::modules::R::langs() {
 
@@ -81,12 +62,6 @@ p6df::modules::R::langs() {
 }
 
 ######################################################################
-#<
-#
-# Function: p6df::modules::R::vscodes()
-#
-#>
-######################################################################
 p6df::modules::R::vscodes() {
 
   p6df::modules::vscode::extension::install REditorSupport.r
@@ -98,18 +73,43 @@ p6df::modules::R::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::R::langmgr::init()
+# Function: p6df::modules::R::deps()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::R::external::brews()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::R::home::symlinks()
 #
 #  Environment:	 P6_DFZ_SRC_DIR
 #>
 ######################################################################
-p6df::modules::R::langmgr::init() {
-
-  p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/viking/Renv" "R"
-
-  p6_return_void
-}
-
+#<
+#
+# Function: p6df::modules::R::langs()
+#
+#>
+#/ Synopsis
+#/  $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
+######################################################################
+#<
+#
+# Function: p6df::modules::R::vscodes()
+#
+#>
+######################################################################
+#<
+#
+# Function: p6df::modules::R::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
 ######################################################################
 #<
 #

--- a/init.zsh
+++ b/init.zsh
@@ -1,5 +1,11 @@
 # shellcheck shell=bash
 ######################################################################
+#<
+#
+# Function: p6df::modules::R::deps()
+#
+#>
+######################################################################
 p6df::modules::R::deps() {
   ModuleDeps=(
     p6m7g8-dotfiles/p6df-python
@@ -9,6 +15,13 @@ p6df::modules::R::deps() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::R::langmgr::init()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
+######################################################################
 p6df::modules::R::langmgr::init() {
 
   p6df::core::lang::mgr::init "$P6_DFZ_SRC_DIR/viking/Renv" "R"
@@ -16,6 +29,13 @@ p6df::modules::R::langmgr::init() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::R::home::symlinks()
+#
+#  Environment:	 P6_DFZ_SRC_DIR
+#>
 ######################################################################
 p6df::modules::R::home::symlinks() {
 
@@ -25,6 +45,12 @@ p6df::modules::R::home::symlinks() {
   p6_return_void
 }
 
+######################################################################
+#<
+#
+# Function: p6df::modules::R::external::brews()
+#
+#>
 ######################################################################
 p6df::modules::R::external::brews() {
 
@@ -62,6 +88,12 @@ p6df::modules::R::langs() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::R::vscodes()
+#
+#>
+######################################################################
 p6df::modules::R::vscodes() {
 
   p6df::modules::vscode::extension::install REditorSupport.r
@@ -73,43 +105,11 @@ p6df::modules::R::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::R::deps()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::R::external::brews()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::R::home::symlinks()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
-######################################################################
-#<
-#
 # Function: p6df::modules::R::langs()
 #
 #>
 #/ Synopsis
 #/  $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
-######################################################################
-#<
-#
-# Function: p6df::modules::R::vscodes()
-#
-#>
-######################################################################
-#<
-#
-# Function: p6df::modules::R::langmgr::init()
-#
-#  Environment:	 P6_DFZ_SRC_DIR
-#>
 ######################################################################
 #<
 #


### PR DESCRIPTION
## What
Reorder hook functions in `init.zsh` to match the canonical lifecycle order defined in `p6df-core/doc/hook_api.md`.

**Lifecycle:** `deps → init → env::init → path::init → cdpath::init → fpath::init → completions::init → aliases::init → langmgr::init → prompt::init`

**Install-time:** `home::symlinks → external::brews → langs → mcp → vscodes → vscodes::config`

**Profile:** `profile::on → profile::off → profile::mod → prompt::mod::bottom`

## Why
Hook functions were defined in inconsistent order across modules. Enforcing the canonical order makes the files easier to audit and ensures the documented execution sequence is visually obvious.

## Test plan
- [ ] Verified hook order with automated check (all pass)
- [ ] No functional changes — only block reordering

## Dependencies
None