### PR TITLE
refactor(R): update function signatures, fix doc placement, rename prompt::env return type

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,17 +36,14 @@ TODO: Add a short summary of this module.
 ##### p6df-R/init.zsh
 
 - `p6df::modules::R::deps()`
-- `p6df::modules::R::external::brew()`
+- `p6df::modules::R::external::brews()`
 - `p6df::modules::R::home::symlinks()`
-- `p6df::modules::R::init(_module, dir)`
-  - Args:
-    - _module -
-    - dir -
+- `p6df::modules::R::langmgr::init()`
 - `p6df::modules::R::langs()`
-  - Synopsis: $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
 - `p6df::modules::R::vscodes()`
-- `str str = p6df::modules::R::prompt::env()`
 - `str str = p6df::modules::R::prompt::lang()`
+  - Synopsis: $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
+- `words R = p6df::modules::R::prompt::env()`
 
 #### p6df-R/lib
 

--- a/init.zsh
+++ b/init.zsh
@@ -60,6 +60,12 @@ p6df::modules::R::external::brews() {
 }
 
 ######################################################################
+#<
+#
+# Function: p6df::modules::R::langs()
+#
+#>
+######################################################################
 p6df::modules::R::langs() {
 
   # nuke the old one
@@ -105,20 +111,14 @@ p6df::modules::R::vscodes() {
 ######################################################################
 #<
 #
-# Function: p6df::modules::R::langs()
-#
-#>
-#/ Synopsis
-#/  $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
-######################################################################
-#<
-#
 # Function: str str = p6df::modules::R::prompt::lang()
 #
 #  Returns:
 #	str - str
 #
 #>
+#/ Synopsis
+#/  $XDG_CONFIG_HOME/radian/profile or $HOME/.config/radian/profile (Unix)
 ######################################################################
 p6df::modules::R::prompt::lang() {
 
@@ -134,10 +134,10 @@ p6df::modules::R::prompt::lang() {
 ######################################################################
 #<
 #
-# Function: words R $RENV_ROOT = p6df::modules::R::prompt::env()
+# Function: words R = p6df::modules::R::prompt::env()
 #
 #  Returns:
-#	words - R $RENV_ROOT
+#	words - R
 #
 #  Environment:	 RENV_ROOT
 #>


### PR DESCRIPTION
**What:** Update function signatures, move synopsis doc to correct function, and fix prompt::env return type declaration

**Why:** Normalizes function documentation to use consistent `words R` return type, fixes misplaced synopsis comment (moved from `langs` to `prompt::lang`), and adds `langmgr::init`

**Test plan:** Shell loads without errors; R prompt functions return expected values

**Dependencies:** none